### PR TITLE
leshan: expose port 8080 for web UI

### DIFF
--- a/leshan/README.md
+++ b/leshan/README.md
@@ -3,5 +3,7 @@ A cross-platform container for the Eclipse [Leshan](https://hudson.eclipse.org/l
 ## How to use this image
 
 ```
-docker run -p5683:5683/udp -p5684:5684/udp hub.foundries.io/leshan
+docker run -p5683:5683/udp -p5684:5684/udp -p8080:8080/tcp hub.foundries.io/leshan
 ```
+
+NOTE: To open the Leshan Web UI goto: http://localhost:8080


### PR DESCRIPTION
We need to explicitly add the port exposure for 8080, so that the user
can access the Leshan web UI at http://localhost:8080.

Signed-off-by: Michael Scott <mike@foundries.io>